### PR TITLE
Support staking and receiving rewards in the chain's native token

### DIFF
--- a/contracts/mock/tokens/MockERC20.sol
+++ b/contracts/mock/tokens/MockERC20.sol
@@ -7,8 +7,9 @@ import { ERC20Mod } from "./ERC20Mod.sol";
 /* solhint-disable */
 contract MockERC20 is ERC20Mod {
     constructor(string memory name, string memory symbol) ERC20Mod(name, symbol) {
-        _mint(msg.sender, 9000000000000 * 10 ** 18);
+        _mint(msg.sender, 999999999999999999 * 10 ** 18);
     }
+
     function mint(address to, uint256 amount) public virtual {
         _mint(to, amount);
     }

--- a/contracts/staking/ERC20/IStakingERC20.sol
+++ b/contracts/staking/ERC20/IStakingERC20.sol
@@ -34,15 +34,20 @@ interface IStakingERC20 {
      */
     error UnstakeMoreThanStake();
 
-    function stakeWithLock(uint256 amount, uint256 lockDuration) external;
+    /**
+     * @notice Revert when the user is staking an amount inequal to the amount given 
+     */
+    error InsufficientValue();
 
-    function stakeWithoutLock(uint256 amount) external;
+    function stakeWithLock(uint256 amount, uint256 lockDuration) external payable;
+
+    function stakeWithoutLock(uint256 amount) external payable;
 
     function claim() external;
 
-    function unstake(uint256 amount, bool exit) external;
+    function unstake(uint256 amount, bool exit) external payable;
 
-    function unstakeLocked(uint256 amount, bool exit) external;
+    function unstakeLocked(uint256 amount, bool exit) external payable;
 
     function getRemainingLockTime() external view returns (uint256);
 

--- a/contracts/staking/ERC20/StakingERC20.sol
+++ b/contracts/staking/ERC20/StakingERC20.sol
@@ -238,7 +238,7 @@ contract StakingERC20 is StakingBase, IStakingERC20 {
             // Transfer the user's rewards
             // Will fail if the contract does not have funding for this
             // If rewards address is `0x0` we use the chain's native token
-            _transferToken(config.rewardsToken, rewards);
+            _transferAmount(config.rewardsToken, rewards);
 
             emit Claimed(msg.sender, rewards);
         }
@@ -246,7 +246,7 @@ contract StakingERC20 is StakingBase, IStakingERC20 {
         totalStaked -= amount;
 
         // Return the user's initial stake
-        _transferToken(config.stakingToken, amount);
+        _transferAmount(config.stakingToken, amount);
 
         // Burn the user's stake representative token
         IERC20MintableBurnable(config.stakeRepToken).burn(msg.sender, amount);

--- a/contracts/staking/ERC20/StakingERC20.sol
+++ b/contracts/staking/ERC20/StakingERC20.sol
@@ -37,7 +37,7 @@ contract StakingERC20 is StakingBase, IStakingERC20 {
      * @param amount The amount to stake
      * @param lockDuration The duration of the lock period
      */
-    function stakeWithLock(uint256 amount, uint256 lockDuration) payable external override {
+    function stakeWithLock(uint256 amount, uint256 lockDuration) external payable override {
         if (lockDuration < config.minimumLockTime) {
             revert LockTimeTooShort();
         }
@@ -51,7 +51,7 @@ contract StakingERC20 is StakingBase, IStakingERC20 {
      *
      * @param amount The amount to stake
      */
-    function stakeWithoutLock(uint256 amount) payable external override {
+    function stakeWithoutLock(uint256 amount) external payable override {
         _stake(amount, 0);
     }
 

--- a/contracts/staking/ERC20/StakingERC20.sol
+++ b/contracts/staking/ERC20/StakingERC20.sol
@@ -26,11 +26,6 @@ contract StakingERC20 is StakingBase, IStakingERC20 {
     ) StakingBase(_config)
     {}
 
-    // We must be able to receive in the case that the
-    // `stakingToken` is the chain's native token
-    receive() external payable {}
-    fallback() external payable {} 
-
     /**
      * @notice Stake an amount of ERC20 with a lock period By locking,
      * a user cannot access their funds until the lock period is over, but they

--- a/contracts/staking/ERC721/IStakingERC721.sol
+++ b/contracts/staking/ERC721/IStakingERC721.sol
@@ -15,7 +15,15 @@ interface IStakingERC721 is IERC721Receiver, IStakingBase {
      */
     struct NFTStaker {
         Staker stake;
-        uint256[] tokenIds;
+
+        // A) have array of token ids AND `staked` mapping
+        // This way we can mark tokens as `unstaked` without iterating
+        // `tokenIds` array each time.
+        // B) we can just remove the `unstakeAll` option because the front end could do this
+        // Considering we don't yet have a subgraph for this it might be tricky
+        uint256[] tokenIds; // use sNFT as proof of ownership of stake, and `amountStaked(locked)` as quantity
+        // TODO look at gas costs for this and see if off chain tids is a better solution (with a subgraph)
+        mapping(uint256 tokenId => bool staked) staked;
         mapping(uint256 tokenId => bool locked) locked;
     }
 

--- a/contracts/staking/ERC721/StakingERC721.sol
+++ b/contracts/staking/ERC721/StakingERC721.sol
@@ -40,7 +40,7 @@ contract StakingERC721 is StakingBase, IStakingERC721 {
     )
         StakingBase(config)
     {
-        if (_config.stakingToken.code.length == 0) {
+        if (config.stakingToken.code.length == 0) {
             revert InitializedWithZero();
         }
 
@@ -306,8 +306,8 @@ contract StakingERC721 is StakingBase, IStakingERC721 {
 
         if (!exit) {
             // Transfer the user's rewards
-            // Will fail if the contract does not have funding
-            config.rewardsToken.safeTransfer(msg.sender, rewards);
+            _transferToken(config.rewardsToken, rewards);
+
             emit Claimed(msg.sender, rewards);
         }
 

--- a/contracts/staking/ERC721/StakingERC721.sol
+++ b/contracts/staking/ERC721/StakingERC721.sol
@@ -39,7 +39,12 @@ contract StakingERC721 is StakingBase, IStakingERC721 {
         Config memory config
     )
         StakingBase(config)
-    {}
+    {
+        if (_config.stakingToken.code.length == 0) {
+            revert InitializedWithZero();
+        }
+
+    }
 
     /**
      * @notice Stake one or more ERC721 tokens with a lock period

--- a/contracts/staking/ERC721/StakingERC721.sol
+++ b/contracts/staking/ERC721/StakingERC721.sol
@@ -4,8 +4,6 @@ pragma solidity 0.8.26;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import { ERC721URIStorage } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import { IStakingERC721 } from "./IStakingERC721.sol";
 import { StakingBase } from "../StakingBase.sol";
 import { IERC721MintableBurnableURIStorage } from "../../types/IERC721MintableBurnableURIStorage.sol";

--- a/contracts/staking/IStakingBase.sol
+++ b/contracts/staking/IStakingBase.sol
@@ -47,7 +47,7 @@ interface IStakingBase {
     struct Config {
         address stakingToken;
         address contractOwner;
-        IERC20 rewardsToken;
+        address rewardsToken;
         address stakeRepToken;
         uint256 rewardsPerPeriod;
         uint256 periodLength;
@@ -201,7 +201,7 @@ interface IStakingBase {
 
     function getStakingToken() external view returns(address);
 
-    function getRewardsToken() external view returns(IERC20);
+    function getRewardsToken() external view returns(address);
 
     function getStakeRepToken() external view returns (address);
 

--- a/contracts/staking/IStakingBase.sol
+++ b/contracts/staking/IStakingBase.sol
@@ -78,6 +78,26 @@ interface IStakingBase {
     );
 
     /**
+     * @notice Emit when `reqwardsPerPeriod` is set
+     * @param owner The address of the contract owner
+     * @param rewardsPerPeriod The new rewards per period value 
+     */
+    event RewardsPerPeriodSet(
+        address indexed owner,
+        uint256 indexed rewardsPerPeriod
+    );
+
+    /**
+     * @notice Emit when the period length is set
+     * @param owner The address of the contract owner
+     * @param periodLength The new period length value
+     */
+    event PeriodLengthSet(
+        address indexed owner,
+        uint256 indexed periodLength
+    );
+
+    /**
      * @notice Emit when the multiplier is set
      * @param owner The address of the contract owner
      * @param multiplier The new multiplier value
@@ -95,6 +115,26 @@ interface IStakingBase {
     event MinimumLockTimeSet(
         address indexed owner,
         uint256 indexed minimumLockTime
+    );
+
+    /**
+     * @notice Emit when the minimum rewards multiplier is set
+     * @param owner The address of the contract owner
+     * @param minimumRewardsMultiplier The new minimum rewards multiplier
+     */
+    event MinimumRewardsMultiplierSet(
+        address indexed owner,
+        uint256 indexed minimumRewardsMultiplier
+    );
+
+    /**
+     * @notice Emit when the maximum rewards multiplier is set
+     * @param owner The address of the contract owner
+     * @param maximumRewardsMultiplier The new maximum rewards multiplier
+     */
+    event MaximumRewardsMultiplierSet(
+        address indexed owner,
+        uint256 indexed maximumRewardsMultiplier
     );
 
     /**

--- a/contracts/staking/IStakingBase.sol
+++ b/contracts/staking/IStakingBase.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /**
  * @title IStakingBase
@@ -184,6 +183,10 @@ interface IStakingBase {
      * @notice Throw when passing zero values to set a state var
      */
     error InitializedWithZero();
+
+    receive() external payable;
+
+    fallback() external payable;
 
     function withdrawLeftoverRewards() external;
 

--- a/contracts/staking/StakingBase.sol
+++ b/contracts/staking/StakingBase.sol
@@ -41,6 +41,11 @@ contract StakingBase is Ownable, ReentrancyGuard, IStakingBase {
         config = _config;
     }
 
+    // We must be able to receive in the case that the
+    // `stakingToken` is the chain's native token
+    receive() external payable {}
+    fallback() external payable {} 
+
     /**
      * @notice Emergency function for the contract owner to withdraw leftover rewards
      * in case of an abandoned contract.

--- a/contracts/staking/StakingBase.sol
+++ b/contracts/staking/StakingBase.sol
@@ -35,8 +35,6 @@ contract StakingBase is Ownable, ReentrancyGuard, IStakingBase {
         Config memory _config
     ) Ownable(_config.contractOwner) {
         if (
-            _config.stakingToken.code.length == 0 ||
-            address(_config.rewardsToken).code.length == 0 ||
             _config.rewardsPerPeriod == 0 ||
             _config.periodLength == 0
         ) revert InitializedWithZero();
@@ -68,6 +66,7 @@ contract StakingBase is Ownable, ReentrancyGuard, IStakingBase {
      */
     function setRewardsPerPeriod(uint256 _rewardsPerPeriod) public override onlyOwner {
         config.rewardsPerPeriod = _rewardsPerPeriod;
+        emit RewardsPerPeriodSet(owner(), _rewardsPerPeriod);
     }
 
     /**
@@ -78,6 +77,7 @@ contract StakingBase is Ownable, ReentrancyGuard, IStakingBase {
      */
     function setPeriodLength(uint256 _periodLength) public override onlyOwner {
         config.periodLength = _periodLength;
+        emit PeriodLengthSet(owner(), _periodLength);
     }
 
     /**
@@ -99,6 +99,7 @@ contract StakingBase is Ownable, ReentrancyGuard, IStakingBase {
      */
     function setMinimumRewardsMultiplier(uint256 _minimumRewardsMultiplier) public override onlyOwner {
         config.minimumRewardsMultiplier = _minimumRewardsMultiplier;
+        emit MinimumRewardsMultiplierSet(owner(), _minimumRewardsMultiplier);
     }
 
     /**
@@ -109,6 +110,7 @@ contract StakingBase is Ownable, ReentrancyGuard, IStakingBase {
      */
     function setMaximumRewardsMultiplier(uint256 _maximumRewardsMultiplier) public override onlyOwner {
         config.maximumRewardsMultiplier = _maximumRewardsMultiplier;
+        emit MaximumRewardsMultiplierSet(owner(), _maximumRewardsMultiplier);
     }
 
     /**
@@ -281,7 +283,11 @@ contract StakingBase is Ownable, ReentrancyGuard, IStakingBase {
 
         if (rewards == 0) revert ZeroRewards();
 
-        config.rewardsToken.safeTransfer(msg.sender, rewards);
+        if (address(config.rewardsToken) == address(0)) {
+            payable(msg.sender).transfer(rewards);
+        } else {
+            config.rewardsToken.safeTransfer(msg.sender, rewards);
+        }
 
         emit Claimed(msg.sender, rewards);
     }

--- a/contracts/staking/StakingBase.sol
+++ b/contracts/staking/StakingBase.sol
@@ -8,7 +8,6 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { IStakingBase } from "./IStakingBase.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-import { console } from "hardhat/console.sol";
 /**
  * @title StakingBase
  * @notice A set of common elements that are used in any Staking contract

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -5,12 +5,13 @@ export const DAY_IN_SECONDS = 86400n;
 export const DEFAULT_REWARDS_PER_PERIOD_ERC20 = 50n;
 export const DEFAULT_PERIOD_LENGTH_ERC20 = 365n * DAY_IN_SECONDS;
 
-export const DEFAULT_REWARDS_PER_PERIOD_ERC721 = ethers.parseEther("1500");
-export const DEFAULT_PERIOD_LENGTH_ERC721 = DAY_IN_SECONDS;
+export const DEFAULT_REWARDS_PER_PERIOD_ERC721 = ethers.parseEther("1000000");
+export const DEFAULT_PERIOD_LENGTH_ERC721 = 365n * DAY_IN_SECONDS;
 
 export const DEFAULT_LOCK = 365n * DAY_IN_SECONDS;
 export const DEFAULT_MINIMUM_LOCK = 30n * DAY_IN_SECONDS;
 
+// 1.0 and 10.0, respectively
 export const DEFAULT_MINIMUM_RM = 100n;
 export const DEFAULT_MAXIMUM_RM = 1000n;
 

--- a/test/helpers/errors.ts
+++ b/test/helpers/errors.ts
@@ -18,6 +18,7 @@ export const OPERATOR_NOT_ASSIGNED_ERR = "OperatorNotAssigned";
 // StakingERC20
 export const UNEQUAL_UNSTAKE_ERR = "UnstakeMoreThanStake";
 export const ZERO_REWARDS_ERR = "ZeroRewards";
+export const INSUFFICIENT_VALUE_ERR = "InsufficientValue";
 
 // StakingERC721
 export const TIME_LOCK_NOT_PASSED_ERR = "TimeLockNotPassed";

--- a/test/helpers/staking/defaults.ts
+++ b/test/helpers/staking/defaults.ts
@@ -102,18 +102,16 @@ export const getNativeSetupERC20 = async (
   );
 
   const localStakingFactory = await hre.ethers.getContractFactory("StakingERC20");
-  const localContract = await localStakingFactory.deploy(config) as StakingERC20;
+  const contract = await localStakingFactory.deploy(config) as StakingERC20;
+  const contractAddress = await contract.getAddress();
 
-  await stakeRepToken.connect(owner).grantRole(await stakeRepToken.MINTER_ROLE(), await localContract.getAddress());
-  await stakeRepToken.connect(owner).grantRole(await stakeRepToken.BURNER_ROLE(), await localContract.getAddress());
+  await stakeRepToken.connect(owner).grantRole(await stakeRepToken.MINTER_ROLE(), contractAddress);
+  await stakeRepToken.connect(owner).grantRole(await stakeRepToken.BURNER_ROLE(), contractAddress);
 
   // Provide rewards funding in native token
-  await owner.sendTransaction({
-    to: await localContract.getAddress(),
-    value: hre.ethers.parseEther("9999"),
-  });
+  fundRewards(contractAddress);
 
-  return localContract;
+  return contract;
 }
 
 export const getNativeSetupERC721 = async (
@@ -132,19 +130,18 @@ export const getNativeSetupERC721 = async (
 
   const stakingFactory = await hre.ethers.getContractFactory("StakingERC721");
   const contract = await stakingFactory.deploy(config) as StakingERC721;
+  const contractAddress = await contract.getAddress();
 
-  await stakeRepToken.connect(owner).grantRole(await stakeRepToken.MINTER_ROLE(), await contract.getAddress());
-  await stakeRepToken.connect(owner).grantRole(await stakeRepToken.BURNER_ROLE(), await contract.getAddress());
+  await stakeRepToken.connect(owner).grantRole(await stakeRepToken.MINTER_ROLE(), contractAddress);
+  await stakeRepToken.connect(owner).grantRole(await stakeRepToken.BURNER_ROLE(), contractAddress);
 
   // Provide rewards funding in native token
-  await owner.sendTransaction({
-    to: await contract.getAddress(),
-    value: hre.ethers.parseEther("9999"),
-  });
+  await fundRewards(contractAddress)
 
   return contract;
 }
 
+// Fund users and approve for an amount
 export const fundAndApprove = async (
   owner : SignerWithAddress,
   addresses : Array<SignerWithAddress>,
@@ -161,4 +158,13 @@ export const fundAndApprove = async (
       contractAddress, amount ?? INIT_BALANCE
     );
   }
+}
+
+
+const fundRewards = async (contractAddress : string) => {
+  await hre.network.provider.send("hardhat_setBalance", [
+    contractAddress,
+    `0x${hre.ethers.parseEther("999999999").toString()}`,
+  ]
+);
 }

--- a/test/helpers/staking/defaults.ts
+++ b/test/helpers/staking/defaults.ts
@@ -70,7 +70,7 @@ export const getDefaultERC20Setup = async (
   rewardsToken : MockERC20,
   stakeToken : MockERC20,
   stakeRepToken : ZeroVotingERC20,
-): Promise<[StakingERC20, BaseConfig]> => {
+) : Promise<[StakingERC20, BaseConfig]> => {
   const config = await createDefaultStakingConfig(
     owner,
     rewardsToken,
@@ -87,7 +87,7 @@ export const getDefaultERC20Setup = async (
   await stakeRepToken.connect(owner).grantRole(await stakeRepToken.BURNER_ROLE(), await contract.getAddress());
 
   return [contract, config];
-}
+};
 
 export const getNativeSetupERC20 = async (
   owner : SignerWithAddress,
@@ -109,10 +109,10 @@ export const getNativeSetupERC20 = async (
   await stakeRepToken.connect(owner).grantRole(await stakeRepToken.BURNER_ROLE(), contractAddress);
 
   // Provide rewards funding in native token
-  fundRewards(contractAddress);
+  await fundRewards(contractAddress);
 
   return contract;
-}
+};
 
 export const getNativeSetupERC721 = async (
   owner : SignerWithAddress,
@@ -136,10 +136,10 @@ export const getNativeSetupERC721 = async (
   await stakeRepToken.connect(owner).grantRole(await stakeRepToken.BURNER_ROLE(), contractAddress);
 
   // Provide rewards funding in native token
-  await fundRewards(contractAddress)
+  await fundRewards(contractAddress);
 
   return contract;
-}
+};
 
 // Fund users and approve for an amount
 export const fundAndApprove = async (
@@ -149,16 +149,17 @@ export const fundAndApprove = async (
   contractAddress : string,
   amount ?: bigint,
 ) => {
-  for (let i = 0; i < addresses.length; i++) {
+  for (const address of addresses) {
     await stakeToken.connect(owner).transfer(
-      addresses[i].address, amount ?? INIT_BALANCE
+      address,
+      amount ?? INIT_BALANCE
     );
 
-    await stakeToken.connect(addresses[i]).approve(
+    await stakeToken.connect(address).approve(
       contractAddress, amount ?? INIT_BALANCE
     );
   }
-}
+};
 
 
 const fundRewards = async (contractAddress : string) => {
@@ -166,5 +167,5 @@ const fundRewards = async (contractAddress : string) => {
     contractAddress,
     `0x${hre.ethers.parseEther("999999999").toString()}`,
   ]
-);
-}
+  );
+};

--- a/test/staking-base.test.ts
+++ b/test/staking-base.test.ts
@@ -9,7 +9,6 @@ import { OWNABLE_UNAUTHORIZED_ERR } from "./helpers/errors";
 describe("StakingBase Unit Tests", () => {
   let owner : SignerWithAddress;
   let user : SignerWithAddress;
-  let mockAcc : SignerWithAddress;
 
   let initialConfig : BaseConfig;
 
@@ -19,7 +18,7 @@ describe("StakingBase Unit Tests", () => {
   let mockErc3 : MockERC20;
 
   before(async () => {
-    [owner, user, mockAcc] = await hre.ethers.getSigners();
+    [owner, user] = await hre.ethers.getSigners();
 
     const erc20Fact = await hre.ethers.getContractFactory("MockERC20");
     mockErc1 = await erc20Fact.deploy("reward", "symbol");
@@ -29,8 +28,8 @@ describe("StakingBase Unit Tests", () => {
     const fact = await hre.ethers.getContractFactory("StakingBase");
 
     initialConfig = await createDefaultStakingConfig(
-      mockErc1,
       owner,
+      mockErc1,
       undefined,
       mockErc2,
       mockErc3 as ZeroVotingERC20,

--- a/test/staking20.test.ts
+++ b/test/staking20.test.ts
@@ -1,7 +1,7 @@
 import * as hre from "hardhat";
 import { expect } from "chai";
 import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
-import { time } from "@nomicfoundation/hardhat-network-helpers";
+import { setBalance, time } from "@nomicfoundation/hardhat-network-helpers";
 import {
   MockERC20,
   StakingERC20, ZeroVotingERC20,
@@ -32,6 +32,9 @@ import {
   calcTotalUnlockedRewards,
   calcStakeRewards,
   DEFAULT_MINIMUM_LOCK,
+  getNativeSetup,
+  getDefaultERC20Setup,
+  fundAndApprove,
 } from "./helpers/staking";
 
 
@@ -75,125 +78,63 @@ describe("StakingERC20", () => {
       rewardsToken = await mockERC20Factory.deploy("WilderWorld", "WW");
       stakeRepToken = await stakeRepFactory.deploy("VotingToken", "VTKN", owner);
 
-      config = await createDefaultStakingConfig(
+      const ownerBal = await hre.ethers.provider.getBalance(owner.address);
+
+      // Give the owner ample funds for transfers in native token case
+      await setBalance(owner.address, INIT_BALANCE * 10n);
+
+      [contract, config] = await getDefaultERC20Setup(
         owner,
         rewardsToken,
-        undefined,
         stakeToken,
         stakeRepToken,
-      );
-
-      contract = await stakingFactory.deploy(config) as StakingERC20;
-
-      await stakeRepToken.connect(owner).grantRole(await stakeRepToken.MINTER_ROLE(), await contract.getAddress());
-      await stakeRepToken.connect(owner).grantRole(await stakeRepToken.BURNER_ROLE(), await contract.getAddress());
+      )
 
       // Give each user funds to stake
-      await stakeToken.connect(owner).transfer(
-        stakerA.address,
-        INIT_BALANCE
+      await fundAndApprove(
+        owner,
+        [
+          stakerA,
+          stakerB,
+          stakerC,
+          stakerD,
+          stakerF,
+        ],
+        stakeToken,
+        await contract.getAddress(),
       );
-
-      await stakeToken.connect(owner).transfer(
-        stakerB.address,
-        INIT_BALANCE
-      );
-
-      await stakeToken.connect(owner).transfer(
-        stakerC.address,
-        INIT_BALANCE
-      );
-
-      await stakeToken.connect(owner).transfer(
-        stakerD.address,
-        INIT_BALANCE
-      );
-
-      await stakeToken.connect(owner).transfer(
-        stakerF.address,
-        INIT_BALANCE
-      );
-
-      // Approve staking contract to spend staker funds
-      await stakeToken.connect(stakerA).approve(await contract.getAddress(), hre.ethers.MaxUint256);
-      await stakeToken.connect(stakerB).approve(await contract.getAddress(), hre.ethers.MaxUint256);
-      await stakeToken.connect(stakerC).approve(await contract.getAddress(), hre.ethers.MaxUint256);
-      await stakeToken.connect(stakerD).approve(await contract.getAddress(), hre.ethers.MaxUint256);
-      await stakeToken.connect(stakerF).approve(await contract.getAddress(), hre.ethers.MaxUint256);
     };
 
     await reset();
   });
 
   describe("#getContractRewardsBalance", () => {
-    it.only("native token flow", async () => {
-      // When neither erc20 or erc721 specified it will assume erc20 with native token
-      // same with rewards
-      config = await createDefaultStakingConfig(
-        owner,
-        undefined,
-        undefined,
-        undefined,
-        stakeRepToken,
-      );
-
-      const localStakingFactory = await hre.ethers.getContractFactory("StakingERC20");
-      const localContract = await localStakingFactory.deploy(config) as StakingERC20;
-
-      await stakeRepToken.connect(owner).grantRole(await stakeRepToken.MINTER_ROLE(), await localContract.getAddress());
-      await stakeRepToken.connect(owner).grantRole(await stakeRepToken.BURNER_ROLE(), await localContract.getAddress());
+    it("it accounts for balance when rewards and stake are same token", async () => {
+      const localContract = await getNativeSetup(owner, stakeRepToken);
 
       // Provide rewards funding in native token
       await owner.sendTransaction({
         to: await localContract.getAddress(),
         value: hre.ethers.parseEther("9999"),
-      })
+      });
 
-      const userBalBefore = await hre.ethers.provider.getBalance(stakerA.address);
-      const contrBalBefore = await hre.ethers.provider.getBalance(await localContract.getAddress());
-
-      
-
-      const stakeTx = await localContract.connect(stakerA).stakeWithoutLock(
-        DEFAULT_STAKED_AMOUNT,
+      const stakeAmount = DEFAULT_STAKED_AMOUNT
+      await localContract.connect(stakerA).stakeWithoutLock(
+        stakeAmount,
         {
-          value: DEFAULT_STAKED_AMOUNT,
+          value: stakeAmount,
         }
       );
-      const stakedAt = BigInt(await time.latest());
 
-      const receipt = await stakeTx.wait();
+      const totalStaked = await localContract.totalStaked();
+      expect(totalStaked).to.eq(stakeAmount);
 
-      const userBalAfter = await hre.ethers.provider.getBalance(stakerA.address);
-      const contrBalAfter = await hre.ethers.provider.getBalance(await localContract.getAddress());
+      const contrRewardsBal = await hre.ethers.provider.getBalance(await localContract.getAddress());
+      const contrRewardsBalFromContract = await localContract.getContractRewardsBalance();
 
-      expect(userBalAfter).to.eq(userBalBefore - DEFAULT_STAKED_AMOUNT - (receipt!.gasUsed * receipt!.gasPrice));
-      expect(contrBalAfter).to.eq(contrBalBefore + DEFAULT_STAKED_AMOUNT);
-
-      await time.increase(DEFAULT_LOCK / 2n);
-
-      const rewardsBefore = await hre.ethers.provider.getBalance(stakerA.address);
-      const contrRewardsBalBefore = await hre.ethers.provider.getBalance(await localContract.getAddress());
-
-
-      const claimTx = await localContract.connect(stakerA).claim();
-      const claimedAt = BigInt(await time.latest());
-
-      const claimReceipt = await claimTx.wait();
-
-      const rewardsAfter = await hre.ethers.provider.getBalance(stakerA.address);
-      const contrRewardsBalAfter = await hre.ethers.provider.getBalance(await localContract.getAddress());
-
-      const stakeRewards = calcStakeRewards(
-        DEFAULT_STAKED_AMOUNT,
-        claimedAt - stakedAt,
-        false,
-        config
-      );
-
-      expect(rewardsAfter).to.eq(rewardsBefore + stakeRewards - (claimReceipt!.gasUsed * claimReceipt!.gasPrice));
-      expect(contrRewardsBalAfter).to.eq(contrRewardsBalBefore - stakeRewards);
+      expect(contrRewardsBalFromContract).to.eq(contrRewardsBal - totalStaked);
     });
+
     it("Allows a user to see the total rewards remaining in a pool", async () => {
       const rewardsInPool = await contract.getContractRewardsBalance();
       const poolBalance = await rewardsToken.balanceOf(await contract.getAddress());
@@ -456,6 +397,10 @@ describe("StakingERC20", () => {
 
       expect(stakerData.lastTimestampLocked).to.eq(stakedAt);
       expect(stakerData.owedRewards).to.eq(0n);
+    });
+
+    it("Fails when using native token and `amount` does not equal `msg.value`", async () => {
+
     });
 
     it("Fails when the staker locks for less than the minimum lock time", async () => {
@@ -1349,6 +1294,143 @@ describe("StakingERC20", () => {
   });
 
   describe("Different configs", async () => {
+    it("Stakes, claims, partially and fully unstakes when stake and reward token are chain token", async () => {
+      // When neither erc20 or erc721 specified it will assume erc20 with native token
+      // same with rewards
+      config = await createDefaultStakingConfig(
+        owner,
+        undefined,
+        undefined,
+        undefined,
+        stakeRepToken,
+      );
+
+      const localStakingFactory = await hre.ethers.getContractFactory("StakingERC20");
+      const localContract = await localStakingFactory.deploy(config) as StakingERC20;
+
+      await stakeRepToken.connect(owner).grantRole(await stakeRepToken.MINTER_ROLE(), await localContract.getAddress());
+      await stakeRepToken.connect(owner).grantRole(await stakeRepToken.BURNER_ROLE(), await localContract.getAddress());
+
+      // Provide rewards funding in native token
+      await owner.sendTransaction({
+        to: await localContract.getAddress(),
+        value: hre.ethers.parseEther("9999"),
+      })
+
+      const userBalBefore = await hre.ethers.provider.getBalance(stakerA.address);
+      const contrBalBefore = await hre.ethers.provider.getBalance(await localContract.getAddress());
+
+      // #stake
+      const stakeAmount = DEFAULT_STAKED_AMOUNT
+      const stakeTx = await localContract.connect(stakerA).stakeWithoutLock(
+        stakeAmount,
+        {
+          value: stakeAmount,
+        }
+      );
+      const stakedAt = BigInt(await time.latest());
+
+      const receipt = await stakeTx.wait();
+
+      const userBalAfter = await hre.ethers.provider.getBalance(stakerA.address);
+      const contrBalAfter = await hre.ethers.provider.getBalance(await localContract.getAddress());
+
+      expect(userBalAfter).to.eq(userBalBefore - stakeAmount - (receipt!.gasUsed * receipt!.gasPrice));
+      expect(contrBalAfter).to.eq(contrBalBefore + stakeAmount);
+
+      await time.increase(DEFAULT_LOCK / 2n);
+
+      const rewardsBefore = await hre.ethers.provider.getBalance(stakerA.address);
+      const contrRewardsBalBefore = await hre.ethers.provider.getBalance(await localContract.getAddress());
+      const contrRewardsBalBeforeFromContract = await localContract.getContractRewardsBalance();
+
+      // If `stakingToken` and `rewardsToken` are the same, we subtract the difference when checking 
+      // the balance. Verify this here.
+      expect(contrRewardsBalBeforeFromContract).to.eq(contrRewardsBalBefore - await localContract.totalStaked());
+
+      // #claim
+      const claimTx = await localContract.connect(stakerA).claim();
+      const claimedAt = BigInt(await time.latest());
+
+      const claimReceipt = await claimTx.wait();
+
+      const rewardsAfter = await hre.ethers.provider.getBalance(stakerA.address);
+      const contrRewardsBalAfter = await hre.ethers.provider.getBalance(await localContract.getAddress());
+      const contrRewardsBalAfterFromContract = await localContract.getContractRewardsBalance();
+
+      const totalStaked = await localContract.totalStaked();
+      expect(contrRewardsBalAfterFromContract).to.eq(contrRewardsBalAfter - totalStaked);
+
+      const stakeRewards = calcStakeRewards(
+        DEFAULT_STAKED_AMOUNT,
+        claimedAt - stakedAt,
+        false,
+        config
+      );
+
+      expect(rewardsAfter).to.eq(
+        rewardsBefore + stakeRewards - (claimReceipt!.gasUsed * claimReceipt!.gasPrice)
+      );
+      expect(contrRewardsBalAfter).to.eq(contrRewardsBalBefore - stakeRewards);
+
+      await time.increase(DEFAULT_LOCK / 2n);
+
+      // Partial unstake
+      const stakerData = await localContract.stakers(stakerA.address);
+      const unstakeAmount = stakerData.amountStaked / 2n;
+
+      const rewardsBeforeUnstake = await hre.ethers.provider.getBalance(stakerA.address);
+
+      // partial #unstake
+      const partialUnstakeTx = await localContract.connect(stakerA).unstake(unstakeAmount, false);
+      const unstakedAt = BigInt(await time.latest());
+
+      const partialUnstakeReceipt = await partialUnstakeTx.wait();
+
+      const stakerDataAfter = await localContract.stakers(stakerA.address);
+
+      const rewardsAfterUnstake = await hre.ethers.provider.getBalance(stakerA.address);
+
+      const stakeRewardsUnstake = calcStakeRewards(
+        unstakeAmount,
+        unstakedAt - claimedAt,
+        false,
+        config
+      );
+
+      expect(stakerDataAfter.amountStaked).to.eq(stakeAmount - unstakeAmount);
+      expect(rewardsAfterUnstake).to.eq(
+        rewardsBeforeUnstake + unstakeAmount + stakeRewardsUnstake
+        - (partialUnstakeReceipt!.gasPrice * partialUnstakeReceipt!.gasUsed)
+      );
+
+      // # full unstake
+      const fullUnstakeTx = await localContract.connect(stakerA).unstake(stakerDataAfter.amountStaked, false);
+      const fullUnstakedAt = BigInt(await time.latest());
+
+      const stakerDataAfterFull = await localContract.stakers(stakerA.address);
+
+      const stakeRewardsFullnstake = calcStakeRewards(
+        stakerDataAfter.amountStaked,
+        fullUnstakedAt - unstakedAt,
+        false,
+        config
+      );
+
+      const rewardsAfterFullUnstake = await hre.ethers.provider.getBalance(stakerA.address);
+
+      const fullUnstakeReceipt = await fullUnstakeTx.wait();
+
+      expect(await localContract.totalStaked()).to.eq(0n);
+      expect(stakerDataAfterFull.amountStaked).to.eq(0n);
+      expect(stakerDataAfterFull.owedRewards).to.eq(0n);
+
+      expect(rewardsAfterFullUnstake).to.eq(
+        rewardsAfterUnstake + stakerDataAfter.amountStaked + stakeRewardsFullnstake
+        - (fullUnstakeReceipt!.gasPrice * fullUnstakeReceipt!.gasUsed)
+      );
+    });
+
     it("Stakes, claims, and unstakes correctly with an entirely different config", async () => {
       // Even though we are manipulating the config here we still reset to be sure all token balances are what we expect
       await reset();

--- a/test/staking20.test.ts
+++ b/test/staking20.test.ts
@@ -396,16 +396,6 @@ describe("StakingERC20", () => {
       expect(stakerData.owedRewards).to.eq(0n);
     });
 
-    it("Fails when using native token and `amount` does not equal `msg.value`", async () => {
-      await expect(
-        contract.connect(stakerA).stakeWithoutLock(DEFAULT_STAKED_AMOUNT,
-          {
-            value: DEFAULT_STAKED_AMOUNT - 1n,
-          }
-        )
-      ).to.be.revertedWithCustomError(contract, INSUFFICIENT_VALUE_ERR);
-    });
-
     it("Fails when the staker locks for less than the minimum lock time", async () => {
       await expect(
         contract.connect(stakerA).stakeWithLock(DEFAULT_STAKED_AMOUNT, DEFAULT_MINIMUM_LOCK - 1n)
@@ -1405,6 +1395,21 @@ describe("StakingERC20", () => {
         rewardsAfterUnstake + stakerDataAfter.amountStaked + stakeRewardsFullnstake
         - (fullUnstakeReceipt!.gasPrice * fullUnstakeReceipt!.gasUsed)
       );
+    });
+
+    it("Fails when using native token and `amount` does not equal `msg.value`", async () => {
+      const localContract = await getNativeSetupERC20(
+        owner,
+        stakeRepToken
+      );
+
+      await expect(
+        localContract.connect(stakerA).stakeWithoutLock(DEFAULT_STAKED_AMOUNT,
+          {
+            value: DEFAULT_STAKED_AMOUNT - 1n,
+          }
+        )
+      ).to.be.revertedWithCustomError(contract, INSUFFICIENT_VALUE_ERR);
     });
 
     it("Stakes, claims, and unstakes correctly with an entirely different config", async () => {


### PR DESCRIPTION
In the ERC20 case one or both values for `stakeToken` and `rewardToken` are able to be `0x0` which we use to indicate the native token is being used, but for ERC721 only the `rewardToken` can be, as is the definition of ERC721 tokens.